### PR TITLE
Add Python 2.6 support

### DIFF
--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -73,10 +73,10 @@ class WSGIAdapter(BaseAdapter):
             'wsgi.url_scheme': urlinfo.scheme,
         }
 
-        environ.update({
-            'HTTP_{}'.format(name).replace('-', '_').upper(): value
+        environ.update(dict(
+            ('HTTP_{0}'.format(name).replace('-', '_').upper(), value)
             for name, value in request.headers.items()
-        })
+        ))
 
         response = Response()
 


### PR DESCRIPTION
This passes setup.py test without problem (quick test using Docker:

```
$ docker run -v $(pwd):/usr/local/src -it centos:6
# yum install -y python-setuptools
# easy_install pytest pip
# make test
```
