### PR TITLE
Wider compatibility testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ develop:
 
 lint:
 	@echo "Linting Python files"
-	flake8 --ignore=E501,E225,E121,E123,E124,E125,E127,E128 wsgiadapter.py
+	# flake8 is not Python 2.6 compatible and Travis runs this anyway for the
+	# rest of Python versions
+	python -c "import sys; sys.exit(0 if sys.version_info >= (2,7) else 1)" && flake8 --ignore=E501,E225,E121,E123,E124,E125,E127,E128 wsgiadapter.py || echo "not linting on python 2.6"
 	@echo ""
 
 test-python:

--- a/tests.py
+++ b/tests.py
@@ -47,3 +47,8 @@ class WSGIAdapterTest(unittest.TestCase):
     def test_request_with_https(self):
         response = self.session.get('https://localhost/index')
         self.assertEqual(response.json()['server_port'], 443)
+
+    def test_request_with_json(self):
+        response = self.session.post('http://localhost/index', json={})
+        self.assertEqual(response.json()['body'], '{}')
+        self.assertEqual(response.json()['content_length'], len('{}'))

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -68,7 +68,14 @@ class WSGIAdapter(BaseAdapter):
 
         urlinfo = urlparse(request.url)
 
-        data = request.body.encode('utf-8') if request.body else b''
+        if not request.body:
+            data = b''
+        # requests>=2.11.0 makes request body a bytes object which no longer needs
+        # encoding
+        elif isinstance(request.body, bytes):
+            data = request.body
+        else:
+            data = request.body.encode('utf-8')
 
         environ = {
             'CONTENT_TYPE': request.headers.get('Content-Type', 'text/plain'),

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -17,6 +17,14 @@ try:
 except ImportError:
     from urlparse import urlparse
 
+try:
+    timedelta_total_seconds = datetime.timedelta.total_seconds
+except AttributeError:
+    def timedelta_total_seconds(timedelta):
+        return (
+            timedelta.microseconds + 0.0 +
+            (timedelta.seconds + timedelta.days * 24 * 3600) * 10 ** 6) / 10 ** 6
+
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +114,7 @@ class WSGIAdapter(BaseAdapter):
                 method=request.method,
                 url=urlinfo.path,
                 host=urlinfo.hostname,
-                time=round(response.elapsed.total_seconds() * 1000, 2),
+                time=round(timedelta_total_seconds(response.elapsed) * 1000, 2),
             )
 
             log(summary)


### PR DESCRIPTION
Hi,

Sorry to be back. It seems that requests 2.11.0 has introduced a breaking change (see https://github.com/kennethreitz/requests/issues/3483 ) on Python 3. As it was annoying me a bit, I've forked, added Travis-CI automated testing for different versions of Python (which simplifies a lot working with all this stuff), rolled my Python 2.6 compatibility changes and added fixes for Python 3/requests 2.11.0.

Even if you don't want to support Python 2.6 (which is terrible, I know), you might want to cherry-pick the other two commits, which will give you automated testing and requests 2.11.0 compatibility.

Cheers,

Álex