### PR TITLE
Change SERVER_PORT to string

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -46,7 +46,7 @@ class WSGIAdapterTest(unittest.TestCase):
 
     def test_request_with_https(self):
         response = self.session.get('https://localhost/index')
-        self.assertEqual(response.json()['server_port'], 443)
+        self.assertEqual(response.json()['server_port'], '443')
 
     def test_request_with_json(self):
         response = self.session.post('http://localhost/index', json={})

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -84,7 +84,7 @@ class WSGIAdapter(BaseAdapter):
             'PATH_INFO': urlinfo.path,
             'REQUEST_METHOD': request.method,
             'SERVER_NAME': urlinfo.hostname,
-            'SERVER_PORT': urlinfo.port or (443 if urlinfo.scheme == 'https' else 80),
+            'SERVER_PORT': urlinfo.port or ('443' if urlinfo.scheme == 'https' else '80'),
             'SERVER_PROTOCOL': self.server_protocol,
             'wsgi.version': self.wsgi_version,
             'wsgi.url_scheme': urlinfo.scheme,


### PR DESCRIPTION
The WSGI spec makes reference to SERVER_PORT being a string. Additionally,
some libraries (like Werkzeug) append environ["SERVER_PORT"] to the hostname
assuming it will be a string. This change makes requests-wsgi-adapter
compatible with Werkzeug and Flask.