### PR TITLE
Add optional third param to start_response

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,7 @@ from wsgiadapter import WSGIAdapter
 class WSGITestHandler(object):
 
     def __call__(self, environ, start_response):
-        start_response('200 OK', {'Content-Type': 'application/json'})
+        start_response('200 OK', {'Content-Type': 'application/json'}, exc_info=None)
         return [bytes(json.dumps({
             'result': '__works__',
             'body': environ['wsgi.input'].read().decode('utf-8'),

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -109,7 +109,7 @@ class WSGIAdapter(BaseAdapter):
 
         response = Response()
 
-        def start_response(status, headers):
+        def start_response(status, headers, exc_info=None):
             response.status_code = int(status.split(' ')[0])
             response.reason = responses.get(response.status_code, 'Unknown Status Code')
             response.headers = CaseInsensitiveDict(headers)


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0333/#the-start-response-callable

Start_response takes an optional third param, that some middleware (such as Beaker) expect to be able to pass on.