### PR TITLE
Support cookie extraction from response

### DIFF
--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -6,6 +6,7 @@ from requests.adapters import BaseAdapter
 from requests.models import Response
 from requests.structures import CaseInsensitiveDict
 from requests.utils import get_encoding_from_headers
+from requests.cookies import extract_cookies_to_jar
 
 try:
     from http.client import responses
@@ -55,6 +56,28 @@ class Content(object):
 
     def release_conn(self):
         pass
+
+
+class MockObject(object):
+    
+    def __getattr__(self, name):
+        setattr(self, name, MockObject())
+        return getattr(self, name)
+
+
+class MockMessage(object):
+
+    def __init__(self, headers):
+        self._headers = CaseInsensitiveDict(headers)
+
+    def info(self):
+        return self
+
+    def getheaders(self, name):
+        header = self._headers.get(name)
+        if header is None:
+            return []
+        return [s.strip() for s in header.split(',')]
 
 
 class WSGIAdapter(BaseAdapter):
@@ -108,11 +131,14 @@ class WSGIAdapter(BaseAdapter):
         ))
 
         response = Response()
+        resp = MockObject()
 
         def start_response(status, headers, exc_info=None):
             response.status_code = int(status.split(' ')[0])
             response.reason = responses.get(response.status_code, 'Unknown Status Code')
             response.headers = CaseInsensitiveDict(headers)
+            resp._original_response.msg = MockMessage(headers)
+            extract_cookies_to_jar(response.cookies, request, resp)
             response.encoding = get_encoding_from_headers(response.headers)
             response.elapsed = datetime.datetime.utcnow() - start
             self._log(response)
@@ -121,6 +147,7 @@ class WSGIAdapter(BaseAdapter):
         response.url = request.url
 
         response.raw = Content(b''.join(self.app(environ, start_response)))
+        response.raw._original_response = resp._original_response
 
         return response
 

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -73,10 +73,12 @@ class MockMessage(object):
     def info(self):
         return self
 
-    def getheaders(self, name):
+    def getheaders(self, name, default=None):
         header = self._headers.get(name)
+        if default is None:
+            default = []
         if header is None:
-            return []
+            return default
         return [s.strip() for s in header.split(',')]
 
     get_all = getheaders

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -79,6 +79,8 @@ class MockMessage(object):
             return []
         return [s.strip() for s in header.split(',')]
 
+    get_all = getheaders
+
 
 class WSGIAdapter(BaseAdapter):
     server_protocol = 'HTTP/1.1'

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -59,7 +59,7 @@ class Content(object):
 
 
 class MockObject(object):
-    
+
     def __getattr__(self, name):
         setattr(self, name, MockObject())
         return getattr(self, name)
@@ -69,9 +69,6 @@ class MockMessage(object):
 
     def __init__(self, headers):
         self._headers = CaseInsensitiveDict(headers)
-
-    def info(self):
-        return self
 
     def getheaders(self, name, default=None):
         header = self._headers.get(name)
@@ -120,7 +117,6 @@ class WSGIAdapter(BaseAdapter):
             'SERVER_PORT': urlinfo.port or ('443' if urlinfo.scheme == 'https' else '80'),
             'SERVER_PROTOCOL': self.server_protocol,
             'wsgi.version': self.wsgi_version,
-            'wsgi.url_scheme': urlinfo.scheme,
             'wsgi.input': Content(data),
             'wsgi.errors': self.errors,
             'wsgi.multiprocess': self.multiprocess,


### PR DESCRIPTION
It is based on the discussion in https://github.com/requests/requests/issues/4214. The original idea comes from @Singletoned 

According to the discussion, I have to mock things to match the interfaces that is used in `requests` and `cookielib`

Also add tests, it works without error.