### PR TITLE
Multiple cookies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=1.0
 httpbin
-nosetests
+pytest
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests>=1.0
+httpbin
+nosetests
+flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests>=1.0
-httpbin
 pytest
 flake8

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'tests': [
             'flake8',
             'pytest',
-            'httpbin',
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'tests': [
             'flake8',
             'pytest',
+            'httpbin',
         ],
     },
     classifiers=[

--- a/tests.py
+++ b/tests.py
@@ -72,3 +72,18 @@ def test_multiple_cookies():
     response = session.get("http://localhost/cookies")
     assert response.json() == {
         'cookies': {'flimble': 'floop', 'flamble': 'flaap'}}
+
+
+def test_delete_cookies():
+    session = requests.session()
+    session.mount('http://localhost', WSGIAdapter(app=httpbin.app))
+    session.get(
+        "http://localhost/cookies/set?flimble=floop&flamble=flaap")
+    response = session.get("http://localhost/cookies")
+    assert response.json() == {
+        'cookies': {'flimble': 'floop', 'flamble': 'flaap'}}
+    response = session.get(
+        "http://localhost/cookies/delete?flimble")
+    result = response.json()
+    expected = {'cookies': {'flamble': 'flaap'}}
+    assert result == expected, result

--- a/tests.py
+++ b/tests.py
@@ -13,7 +13,7 @@ class WSGITestHandler(object):
     def __call__(self, environ, start_response):
         headers = {'Content-Type': 'application/json'}
         if environ['PATH_INFO'].startswith('/cookies'):
-            headers['Set-Cookie'] = 'c1=v1; Path=/, c2=v2; Path=/'
+            headers['Set-Cookie'] = 'c1=v1; Path=/'
         start_response('200 OK', headers, exc_info=None)
         return [bytes(json.dumps({
             'result': '__works__',
@@ -61,7 +61,7 @@ class WSGIAdapterTest(unittest.TestCase):
     def test_request_with_cookies(self):
         response = self.session.get('http://localhost/cookies')
         self.assertEqual(response.cookies['c1'], 'v1')
-        self.assertEqual(self.session.cookies['c2'], 'v2')
+        self.assertEqual(self.session.cookies['c1'], 'v1')
 
 
 def test_multiple_cookies():

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,8 @@ import unittest
 
 import requests
 
+import httpbin
+
 from wsgiadapter import WSGIAdapter
 
 
@@ -60,3 +62,13 @@ class WSGIAdapterTest(unittest.TestCase):
         response = self.session.get('http://localhost/cookies')
         self.assertEqual(response.cookies['c1'], 'v1')
         self.assertEqual(self.session.cookies['c2'], 'v2')
+
+
+def test_multiple_cookies():
+    session = requests.session()
+    session.mount('http://localhost', WSGIAdapter(app=httpbin.app))
+    session.get(
+        "http://localhost/cookies/set?flimble=floop&flamble=flaap")
+    response = session.get("http://localhost/cookies")
+    assert response.json() == {
+        'cookies': {'flimble': 'floop', 'flamble': 'flaap'}}

--- a/tests.py
+++ b/tests.py
@@ -2,18 +2,19 @@ import json
 import unittest
 
 import requests
-
-import httpbin
+from urllib3._collections import HTTPHeaderDict
 
 from wsgiadapter import WSGIAdapter
 
 
 class WSGITestHandler(object):
+    def __init__(self, extra_headers=None):
+        self.extra_headers = extra_headers or tuple()
 
     def __call__(self, environ, start_response):
-        headers = {'Content-Type': 'application/json'}
-        if environ['PATH_INFO'].startswith('/cookies'):
-            headers['Set-Cookie'] = 'c1=v1; Path=/'
+        headers = HTTPHeaderDict({'Content-Type': 'application/json'})
+        for key, value in self.extra_headers:
+            headers.add(key, value)
         start_response('200 OK', headers, exc_info=None)
         return [bytes(json.dumps({
             'result': '__works__',
@@ -58,32 +59,58 @@ class WSGIAdapterTest(unittest.TestCase):
         self.assertEqual(response.json()['body'], '{}')
         self.assertEqual(response.json()['content_length'], len('{}'))
 
+
+class WSGIAdapterCookieTest(unittest.TestCase):
+    def setUp(self):
+        app = WSGITestHandler(
+            extra_headers=[
+                ("Set-Cookie", "c1=v1; Path=/"),
+                ("Set-Cookie", "c2=v2; Path=/")])
+        self.session = requests.session()
+        self.session.mount('http://localhost', WSGIAdapter(app=app))
+        self.session.mount('https://localhost', WSGIAdapter(app=app))
+
     def test_request_with_cookies(self):
-        response = self.session.get('http://localhost/cookies')
+        response = self.session.get("http://localhost/cookies")
         self.assertEqual(response.cookies['c1'], 'v1')
         self.assertEqual(self.session.cookies['c1'], 'v1')
 
 
 def test_multiple_cookies():
+    app = WSGITestHandler(
+        extra_headers=[
+            ("Set-Cookie", "flimble=floop; Path=/"),
+            ("Set-Cookie", "flamble=flaap; Path=/")])
     session = requests.session()
-    session.mount('http://localhost', WSGIAdapter(app=httpbin.app))
+    session.mount('http://localhost', WSGIAdapter(app=app))
+
     session.get(
         "http://localhost/cookies/set?flimble=floop&flamble=flaap")
-    response = session.get("http://localhost/cookies")
-    assert response.json() == {
-        'cookies': {'flimble': 'floop', 'flamble': 'flaap'}}
+    assert session.cookies['flimble'] == "floop"
+    assert session.cookies['flamble'] == "flaap"
 
 
 def test_delete_cookies():
     session = requests.session()
-    session.mount('http://localhost', WSGIAdapter(app=httpbin.app))
+    set_app = WSGITestHandler(
+        extra_headers=[
+            ("Set-Cookie", "flimble=floop; Path=/"),
+            ("Set-Cookie", "flamble=flaap; Path=/")])
+    delete_app = WSGITestHandler(
+        extra_headers=[(
+            "Set-Cookie",
+            "flimble=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/")])
+    session.mount(
+        'http://localhost/cookies/set', WSGIAdapter(app=set_app))
+    session.mount(
+        'http://localhost/cookies/delete', WSGIAdapter(app=delete_app))
+
     session.get(
         "http://localhost/cookies/set?flimble=floop&flamble=flaap")
-    response = session.get("http://localhost/cookies")
-    assert response.json() == {
-        'cookies': {'flimble': 'floop', 'flamble': 'flaap'}}
-    response = session.get(
+    assert session.cookies['flimble'] == "floop"
+    assert session.cookies['flamble'] == "flaap"
+
+    session.get(
         "http://localhost/cookies/delete?flimble")
-    result = response.json()
-    expected = {'cookies': {'flamble': 'flaap'}}
-    assert result == expected, result
+    assert 'flimble' not in session.cookies
+    assert session.cookies['flamble'] == "flaap"

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -66,23 +66,6 @@ class MockObject(object):
         return getattr(self, name)
 
 
-SENTINEL = object()
-
-
-class MockMessage(object):
-
-    def __init__(self, headers):
-        self._headers = headers
-
-    def getheaders(self, name, default=SENTINEL):
-        if default == SENTINEL:
-            return self._headers.getheaders(name)
-        else:
-            return self._headers.getheaders(name, default)
-
-    get_all = getheaders
-
-
 def make_headers(headers):
     if hasattr(headers, 'items'):
         headers = headers.items()
@@ -149,7 +132,7 @@ class WSGIAdapter(BaseAdapter):
             response.status_code = int(status.split(' ')[0])
             response.reason = responses.get(response.status_code, 'Unknown Status Code')
             response.headers = headers
-            resp._original_response.msg = MockMessage(headers)
+            resp._original_response.msg = headers
             extract_cookies_to_jar(response.cookies, request, resp)
             response.encoding = get_encoding_from_headers(response.headers)
             response.elapsed = datetime.datetime.utcnow() - start

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -85,7 +85,7 @@ class MockMessage(object):
 
 
 def make_headers(headers):
-    if isinstance(headers, dict):
+    if hasattr(headers, 'items'):
         headers = headers.items()
     header_dict = HTTPHeaderDict()
     for key, value in headers:

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -81,6 +81,19 @@ class MockMessage(object):
     get_all = getheaders
 
 
+def make_headers(header_list):
+    if isinstance(header_list, dict):
+        d = header_list
+    else:
+        d = {}
+        for k, v in header_list:
+            if k in d:
+                d[k] = ", ".join((d[k], v))
+            else:
+                d[k] = v
+    return CaseInsensitiveDict(d)
+
+
 class WSGIAdapter(BaseAdapter):
     server_protocol = 'HTTP/1.1'
     wsgi_version = (1, 0)
@@ -136,8 +149,8 @@ class WSGIAdapter(BaseAdapter):
         def start_response(status, headers, exc_info=None):
             response.status_code = int(status.split(' ')[0])
             response.reason = responses.get(response.status_code, 'Unknown Status Code')
-            response.headers = CaseInsensitiveDict(headers)
-            resp._original_response.msg = MockMessage(headers)
+            response.headers = make_headers(headers)
+            resp._original_response.msg = MockMessage(response.headers)
             extract_cookies_to_jar(response.cookies, request, resp)
             response.encoding = get_encoding_from_headers(response.headers)
             response.elapsed = datetime.datetime.utcnow() - start

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -66,7 +66,6 @@ class MockObject(object):
         return getattr(self, name)
 
 
-
 SENTINEL = object()
 
 


### PR DESCRIPTION
Handles setting multiple cookies through multiple `Set-cookie` headers.  Also adds httpbin when testing, for convenience.  I might expand on this a bit more later.  It makes testing very convenient.