### PR TITLE
Make environ['SERVER_PORT'] str consistently

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -32,8 +32,11 @@ class WSGIAdapterTest(unittest.TestCase):
 
     def setUp(self):
         self.session = requests.session()
-        self.session.mount('http://localhost', WSGIAdapter(app=WSGITestHandler()))
-        self.session.mount('https://localhost', WSGIAdapter(app=WSGITestHandler()))
+        adapter = WSGIAdapter(app=WSGITestHandler())
+        self.session.mount('http://localhost', adapter)
+        self.session.mount('http://localhost:5000', adapter)
+        self.session.mount('https://localhost', adapter)
+        self.session.mount('https://localhost:5443', adapter)
 
     def test_basic_response(self):
         response = self.session.get('http://localhost/index', headers={'Content-Type': 'application/json'})
@@ -58,6 +61,16 @@ class WSGIAdapterTest(unittest.TestCase):
         response = self.session.post('http://localhost/index', json={})
         self.assertEqual(response.json()['body'], '{}')
         self.assertEqual(response.json()['content_length'], len('{}'))
+
+    def test_server_port(self):
+        response = self.session.get('http://localhost/index')
+        self.assertEqual(response.json()['server_port'], '80')
+        response = self.session.get('http://localhost:5000/index')
+        self.assertEqual(response.json()['server_port'], '5000')
+        response = self.session.get('https://localhost/index')
+        self.assertEqual(response.json()['server_port'], '443')
+        response = self.session.get('https://localhost:5443/index')
+        self.assertEqual(response.json()['server_port'], '5443')
 
 
 class WSGIAdapterCookieTest(unittest.TestCase):

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -108,7 +108,7 @@ class WSGIAdapter(BaseAdapter):
             'REQUEST_METHOD': request.method,
             'SERVER_NAME': urlinfo.hostname,
             'QUERY_STRING': urlinfo.query,
-            'SERVER_PORT': urlinfo.port or ('443' if urlinfo.scheme == 'https' else '80'),
+            'SERVER_PORT': str(urlinfo.port or (443 if urlinfo.scheme == 'https' else 80)),
             'SERVER_PROTOCOL': self.server_protocol,
             'wsgi.version': self.wsgi_version,
             'wsgi.input': Content(data),


### PR DESCRIPTION
Value of `environ['SERVER_PORT']` is now consistently `str`, making Werkzeug happy.
See also https://github.com/seanbrant/requests-wsgi-adapter/pull/3.