### PR TITLE
fix PATH_INFO  according to https://tools.ietf.org/html/rfc3875#section-4.1.5

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -64,9 +64,9 @@ class WSGIAdapterTest(unittest.TestCase):
 
     def test_request_i18n_path(self):
         response = self.session.get('http://localhost/привет', json={})
-        self.assertEqual(response.json()['path_info'], '/привет')
+        self.assertEqual(response.json()['path_info'], u'/привет')
         response = self.session.get('http://localhost/Moselfränkisch', json={})
-        self.assertEqual(response.json()['path_info'], '/Moselfränkisch')
+        self.assertEqual(response.json()['path_info'], u'/Moselfränkisch')
 
 
 class WSGIAdapterCookieTest(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -21,7 +21,9 @@ class WSGITestHandler(object):
             'body': environ['wsgi.input'].read().decode('utf-8'),
             'content_type': environ['CONTENT_TYPE'],
             'content_length': environ['CONTENT_LENGTH'],
-            'path_info': environ['PATH_INFO'],
+            # The Common Gateway Interface (CGI) Version 1.1
+            # compatibly with https://tools.ietf.org/html/rfc3875#section-4.1.5
+            'path_info': environ['PATH_INFO'].encode('latin-1').decode('utf-8'),
             'request_method': environ['REQUEST_METHOD'],
             'server_name': environ['SERVER_NAME'],
             'server_port': environ['SERVER_PORT'],
@@ -58,6 +60,12 @@ class WSGIAdapterTest(unittest.TestCase):
         response = self.session.post('http://localhost/index', json={})
         self.assertEqual(response.json()['body'], '{}')
         self.assertEqual(response.json()['content_length'], len('{}'))
+
+    def test_request_i18n_path(self):
+        response = self.session.get('http://localhost/привет', json={})
+        self.assertEqual(response.json()['path_info'], '/привет')
+        response = self.session.get('http://localhost/Moselfränkisch', json={})
+        self.assertEqual(response.json()['path_info'], '/Moselfränkisch')
 
 
 class WSGIAdapterCookieTest(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -22,11 +22,8 @@ class WSGITestHandler(object):
             'body': environ['wsgi.input'].read().decode('utf-8'),
             'content_type': environ['CONTENT_TYPE'],
             'content_length': environ['CONTENT_LENGTH'],
-            # The Common Gateway Interface (CGI) Version 1.1
-            # compatibly with https://tools.ietf.org/html/rfc3875#section-4.1.5
             'path_info': environ['PATH_INFO'].encode('latin-1').decode('utf-8'),
             'script_name': environ['SCRIPT_NAME'],
-            'path_info': environ['PATH_INFO'],
             'request_method': environ['REQUEST_METHOD'],
             'server_name': environ['SERVER_NAME'],
             'server_port': environ['SERVER_PORT'],

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 import unittest
 

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -19,6 +19,8 @@ try:
 except ImportError:
     from urlparse import urlparse
 
+from urllib.parse import unquote
+
 try:
     timedelta_total_seconds = datetime.timedelta.total_seconds
 except AttributeError:
@@ -104,7 +106,10 @@ class WSGIAdapter(BaseAdapter):
         environ = {
             'CONTENT_TYPE': request.headers.get('Content-Type', 'text/plain'),
             'CONTENT_LENGTH': len(data),
-            'PATH_INFO': urlinfo.path,
+            # The Common Gateway Interface (CGI) Version 1.1
+            # compatibly with https://tools.ietf.org/html/rfc3875#section-4.1.5
+            # adapter must return PATH_INFO string in encoding latin-1
+            'PATH_INFO': unquote(urlinfo.path, encoding='latin-1'),
             'REQUEST_METHOD': request.method,
             'SERVER_NAME': urlinfo.hostname,
             'QUERY_STRING': urlinfo.query,

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -114,7 +114,6 @@ class WSGIAdapter(BaseAdapter):
             'CONTENT_LENGTH': len(data),
             'PATH_INFO': unquote(urlinfo.path, encoding='latin-1'),
             'SCRIPT_NAME': '',
-            'PATH_INFO': urlinfo.path,
             'REQUEST_METHOD': request.method,
             'SERVER_NAME': urlinfo.hostname,
             'QUERY_STRING': urlinfo.query,

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -22,7 +22,10 @@ except ImportError:
 try:
     from urllib.parse import unquote
 except ImportError:
-    from urlparse import unquote
+    from urllib2 import unquote as unquote2
+
+    def unquote(s, encoding):
+        return unquote2(s.decode(encoding))
 
 try:
     timedelta_total_seconds = datetime.timedelta.total_seconds

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -19,7 +19,10 @@ try:
 except ImportError:
     from urlparse import urlparse
 
-from urllib.parse import unquote
+try:
+    from urllib.parse import unquote
+except ImportError:
+    from urlparse import unquote
 
 try:
     timedelta_total_seconds = datetime.timedelta.total_seconds


### PR DESCRIPTION
Adapter must return variable PATH_INFO as string in encoding laitin-1
... 
Unlike a URI path, the PATH_INFO is not URL-encoded
...