### PR TITLE
Add SCRIPT_NAME to environment

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -21,6 +21,7 @@ class WSGITestHandler(object):
             'body': environ['wsgi.input'].read().decode('utf-8'),
             'content_type': environ['CONTENT_TYPE'],
             'content_length': environ['CONTENT_LENGTH'],
+            'script_name': environ['SCRIPT_NAME'],
             'path_info': environ['PATH_INFO'],
             'request_method': environ['REQUEST_METHOD'],
             'server_name': environ['SERVER_NAME'],
@@ -41,6 +42,7 @@ class WSGIAdapterTest(unittest.TestCase):
         self.assertEqual(response.headers['Content-Type'], 'application/json')
         self.assertEqual(response.json()['result'], '__works__')
         self.assertEqual(response.json()['content_type'], 'application/json')
+        self.assertEqual(response.json()['script_name'], '')
         self.assertEqual(response.json()['path_info'], '/index')
         self.assertEqual(response.json()['request_method'], 'GET')
         self.assertEqual(response.json()['server_name'], 'localhost')

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -104,6 +104,7 @@ class WSGIAdapter(BaseAdapter):
         environ = {
             'CONTENT_TYPE': request.headers.get('Content-Type', 'text/plain'),
             'CONTENT_LENGTH': len(data),
+            'SCRIPT_NAME': '',
             'PATH_INFO': urlinfo.path,
             'REQUEST_METHOD': request.method,
             'SERVER_NAME': urlinfo.hostname,


### PR DESCRIPTION
This is required by PEP333[1] and RFC3875[2].  At least one popular
Python web framework (Pyramid) counts on this value being provided.

[1]: https://www.python.org/dev/peps/pep-0333/
[2]: https://tools.ietf.org/html/rfc3875#section-4.1.13