### PR TITLE
Do not set "Content-Type: text/plain" on binary requests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -59,6 +59,21 @@ class WSGIAdapterTest(unittest.TestCase):
         self.assertEqual(response.json()['body'], '{}')
         self.assertEqual(response.json()['content_length'], len('{}'))
 
+    def test_plain_text(self):
+        response = self.session.post('http://localhost/index', data='Once upon a time...')
+        self.assertEqual(response.json()['body'], 'Once upon a time...')
+        self.assertEqual(response.json()['content_type'], 'text/plain')
+
+    def test_blob(self):
+        response = self.session.post('http://localhost/index', data=b'bliblob')
+        self.assertEqual(response.json()['body'], 'bliblob')
+        self.assertEqual(response.json()['content_type'], 'application/octet-stream')
+
+    def test_empty(self):
+        response = self.session.post('http://localhost/index')
+        self.assertEqual(response.json()['body'], '')
+        self.assertEqual(response.json()['content_type'], None)
+
 
 class WSGIAdapterCookieTest(unittest.TestCase):
     def setUp(self):

--- a/tests.py
+++ b/tests.py
@@ -77,17 +77,14 @@ class WSGIAdapterTest(unittest.TestCase):
     def test_plain_text(self):
         response = self.session.post('http://localhost/index', data='Once upon a time...')
         self.assertEqual(response.json()['body'], 'Once upon a time...')
-        self.assertEqual(response.json()['content_type'], 'text/plain')
 
     def test_blob(self):
         response = self.session.post('http://localhost/index', data=b'bliblob')
         self.assertEqual(response.json()['body'], 'bliblob')
-        self.assertEqual(response.json()['content_type'], 'application/octet-stream')
 
     def test_empty(self):
         response = self.session.post('http://localhost/index')
         self.assertEqual(response.json()['body'], '')
-        self.assertEqual(response.json()['content_type'], None)
 
 
 class WSGIAdapterCookieTest(unittest.TestCase):

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -92,22 +92,17 @@ class WSGIAdapter(BaseAdapter):
 
         urlinfo = urlparse(request.url)
 
-        content_type = None
         if not request.body:
             data = b''
         # requests>=2.11.0 makes request body a bytes object which no longer needs
         # encoding
         elif isinstance(request.body, str):
             data = request.body.encode('utf-8')
-            # TODO: remove?
-            content_type = 'text/plain'
         else:
             data = request.body
-            # TODO: remove?
-            content_type = 'application/octet-stream'
 
         environ = {
-            'CONTENT_TYPE': request.headers.get('Content-Type', content_type),
+            'CONTENT_TYPE': request.headers.get('Content-Type', ''),
             'CONTENT_LENGTH': len(data),
             'SCRIPT_NAME': '',
             'PATH_INFO': urlinfo.path,

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -92,17 +92,22 @@ class WSGIAdapter(BaseAdapter):
 
         urlinfo = urlparse(request.url)
 
+        content_type = None
         if not request.body:
             data = b''
         # requests>=2.11.0 makes request body a bytes object which no longer needs
         # encoding
         elif isinstance(request.body, bytes):
             data = request.body
+            # TODO: remove?
+            content_type = 'application/octet-stream'
         else:
             data = request.body.encode('utf-8')
+            # TODO: remove?
+            content_type = 'text/plain'
 
         environ = {
-            'CONTENT_TYPE': request.headers.get('Content-Type', 'text/plain'),
+            'CONTENT_TYPE': request.headers.get('Content-Type', content_type),
             'CONTENT_LENGTH': len(data),
             'PATH_INFO': urlinfo.path,
             'REQUEST_METHOD': request.method,

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -97,14 +97,14 @@ class WSGIAdapter(BaseAdapter):
             data = b''
         # requests>=2.11.0 makes request body a bytes object which no longer needs
         # encoding
-        elif isinstance(request.body, bytes):
-            data = request.body
-            # TODO: remove?
-            content_type = 'application/octet-stream'
-        else:
+        elif isinstance(request.body, str):
             data = request.body.encode('utf-8')
             # TODO: remove?
             content_type = 'text/plain'
+        else:
+            data = request.body
+            # TODO: remove?
+            content_type = 'application/octet-stream'
 
         environ = {
             'CONTENT_TYPE': request.headers.get('Content-Type', content_type),


### PR DESCRIPTION
Currently sets `Content-Type: application/octet-stream` instead, but probably should default to `None` always.