### PR TITLE
Reference the adapter object by `connection` attribute of Response object

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -47,12 +47,14 @@ class WSGIAdapterTest(unittest.TestCase):
         self.session.mount("http://localhost:5000", adapter)
         self.session.mount("https://localhost", adapter)
         self.session.mount("https://localhost:5443", adapter)
+        self.adapter = adapter
 
     def test_basic_response(self):
         response = self.session.get(
             "http://localhost/index", headers={"Content-Type": "application/json"}
         )
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.connection, self.adapter)
         self.assertEqual(response.headers["Content-Type"], "application/json")
         self.assertEqual(response.json()["result"], "__works__")
         self.assertEqual(response.json()["content_type"], "application/json")

--- a/wsgiadapter.py
+++ b/wsgiadapter.py
@@ -171,6 +171,7 @@ class WSGIAdapter(BaseAdapter):
             self._log(response)
 
         response.request = request
+        response.connection = self
         response.url = request.url
 
         response.raw = Content(b"".join(self.app(environ, start_response)))


### PR DESCRIPTION
This is to keep consistent with requests's behavior:

https://github.com/psf/requests/blob/40956723f27daf5e0d9759208ca69cef236ab339/requests/adapters.py#L329